### PR TITLE
Make baseurl use https

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "//colemickens.io"
+baseurl = "https://colemickens.io"
 languageCode = "en-us"
 title = "mickens"
 theme = "hyde"


### PR DESCRIPTION
Prevents mixed content issues. Right now, images and CSS don't load on your site. With this change, they should. I had the same issue on my site.
